### PR TITLE
[modify] 入力文字数とプロンプトの文言変更

### DIFF
--- a/frontend/src/components/QuestionInput/QuestionInput.tsx
+++ b/frontend/src/components/QuestionInput/QuestionInput.tsx
@@ -43,7 +43,7 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, init
     const onQuestionChange = (_ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
         if (!newValue) {
             setQuestion("");
-        } else if (newValue.length <= 1000) {
+        } else if (newValue.length <= 100000) {
             setQuestion(newValue);
         }
     };

--- a/src/quartapp/approaches/rag.py
+++ b/src/quartapp/approaches/rag.py
@@ -24,13 +24,12 @@ def get_data_points(documents: list[Document]) -> list[DataPoint]:
 
 
 REPHRASE_PROMPT = """\
-Given the following conversation and a follow up question, rephrase the follow up \
-question to be a standalone question.
+以下の会話に基づいて、フォローアップ質問を独立した質問に言い換えてください。
 
-Chat History:
+チャット履歴:
 {chat_history}
-Follow Up Input: {question}
-Standalone Question:"""
+フォローアップ質問: {question}
+独立した質問:"""
 
 CONTEXT_PROMPT = """\
 あなたは勤怠と契約が辻褄が合っているか確認するアシスタントです。​
@@ -240,9 +239,11 @@ CONTEXT_PROMPT = """\
 
 氏 名：山田 花子 印​\
 
-User Question: {input}
+# ユーザーの質問
+ユーザーの質問: {input}
 
-Chatbot Response:"""
+# チャットボットの応答
+チャットボットの応答:"""
 
 
 class RAG(ApproachesBase):


### PR DESCRIPTION
This pull request includes changes to the `QuestionInput` component and updates to the `rag.py` file to support Japanese language prompts. The most important changes are listed below:

### Component Updates:
* [`frontend/src/components/QuestionInput/QuestionInput.tsx`](diffhunk://#diff-e75b5848220735d69ec9bbde2b6846ae6776415e0e7eddbf9f120a61b962126fL46-R46): Increased the maximum allowed length for question input from 1000 to 100000 characters.

### Localization Updates:
* [`src/quartapp/approaches/rag.py`](diffhunk://#diff-6b4b2d4b03a253aa937f3a11e546fbc231306bd7989fc9533238560821e7da09L27-R32): Translated the `REPHRASE_PROMPT` and `CONTEXT_PROMPT` to Japanese to support localization.
* [`src/quartapp/approaches/rag.py`](diffhunk://#diff-6b4b2d4b03a253aa937f3a11e546fbc231306bd7989fc9533238560821e7da09L243-R246): Translated user and chatbot labels to Japanese within the `get_data_points` function.